### PR TITLE
Adding a new built-in parser called "firstlastdayof"

### DIFF
--- a/parseplus.js
+++ b/parseplus.js
@@ -400,6 +400,27 @@
 				var mult = match[1] == '-' ? -1 : 1;
 				return moment().add(mult * parseFloat(match[2]), match[3]);
 			}
+		}),
+		.addParser({
+			name: 'firstlastdayof',
+			matcher: /^(first|last) day of (last|this|next) (month|year)/i,
+			handler: function(match) {
+				var date = moment();
+				switch (match[2].toLowerCase()) {
+					case "last":
+						date = date.subtract(1, match[3].toLowerCase());
+						break;
+					case "next":
+						date = date.add(1, match[3].toLowerCase());
+						break;
+				}
+				switch (match[1].toLowerCase()) {
+					case "first":
+						return date.startOf(match[3].toLowerCase());
+					case "last":
+						return date.endOf(match[3].toLowerCase());
+				}
+			}
 		})
 	;
 


### PR DESCRIPTION
I found those really useful:

- "first day of last month"
- "last day of last month"
- "first day of this month"
- "last day of this month"
- "first day of next month"
- "last day of next month"
- "first day of last year"
- "last day of last year"
- "first day of this year"
- "last day of this year"
- "first day of next year"
- "last day of next year"